### PR TITLE
Add `Furi` class and remove repeated slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+- **[Breaking change]** Remove repeated slashes from pathnames.
+- **[Feature]** Add `Furi` class enforcing file URI invariants.
 - **[Feature]** Add `basename`.
 - **[Feature]** Add `append`.
 - **[Fix]** Update dependencies.

--- a/src/test/append.spec.ts
+++ b/src/test/append.spec.ts
@@ -31,12 +31,12 @@ const testItems: TestItem[] = [
   {
     base: "file:///foo",
     uriPaths: ["bar//baz"],
-    expected: "file:///foo/bar//baz",
+    expected: "file:///foo/bar/baz",
   },
   {
     base: "file:///foo",
     uriPaths: ["bar///baz"],
-    expected: "file:///foo/bar///baz",
+    expected: "file:///foo/bar/baz",
   },
   {
     name: "append nothing",
@@ -72,7 +72,7 @@ const testItems: TestItem[] = [
     name: "append a double-slash uriPath",
     base: "file:///foo",
     uriPaths: ["//"],
-    expected: "file:///foo//",
+    expected: "file:///foo/",
   },
   {
     name: "append a simple uriPath to a base with a trailing slash",
@@ -104,12 +104,12 @@ const testItems: TestItem[] = [
   {
     base: "file:///foo/",
     uriPaths: ["bar//", "/baz"],
-    expected: "file:///foo/bar//baz",
+    expected: "file:///foo/bar/baz",
   },
   {
     base: "file:///foo/",
     uriPaths: ["bar//", "//baz"],
-    expected: "file:///foo/bar///baz",
+    expected: "file:///foo/bar/baz",
   },
   {
     base: "file:///foo/",
@@ -119,27 +119,27 @@ const testItems: TestItem[] = [
   {
     base: "file:///foo//",
     uriPaths: ["bar/", "/baz/"],
-    expected: "file:///foo//bar/baz/",
+    expected: "file:///foo/bar/baz/",
   },
   {
     base: "file:///foo//",
     uriPaths: ["bar//", "baz//"],
-    expected: "file:///foo//bar//baz//",
+    expected: "file:///foo/bar/baz/",
   },
   {
     base: "file:///foo//",
     uriPaths: ["bar//", "", "baz//"],
-    expected: "file:///foo//bar//baz//",
+    expected: "file:///foo/bar/baz/",
   },
   {
     base: "file:///foo//",
     uriPaths: ["bar//", "", "/baz//"],
-    expected: "file:///foo//bar//baz//",
+    expected: "file:///foo/bar/baz/",
   },
   {
     base: "file:///foo//",
     uriPaths: ["bar//", "/", "/baz//"],
-    expected: "file:///foo//bar//baz//",
+    expected: "file:///foo/bar/baz/",
   },
   {
     base: "file:///foo",

--- a/src/test/join.spec.ts
+++ b/src/test/join.spec.ts
@@ -38,7 +38,7 @@ const testItems: TestItem[] = [
     name: "lowercase ascii alpha, 2 empty string components",
     base: "file:///foo",
     components: ["", ""],
-    expected: "file:///foo//",
+    expected: "file:///foo/",
   },
   {
     name: "trailing separator, 1 simple component",
@@ -68,7 +68,7 @@ const testItems: TestItem[] = [
     name: "trailing separator, 2 empty string components",
     base: "file:///foo/",
     components: ["", ""],
-    expected: "file:///foo//",
+    expected: "file:///foo/",
   },
   {
     name: "root, 1 simple component",


### PR DESCRIPTION
This commit adds the `Furi` class. It is a subclass of `url.URL` that enforces file URI invariants at runtime: it ensures the protocol is `file:` and there are no repeated slashes in the pathname.