### PR TITLE
Add convenience methods to `Furi` to convert to path

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -90,6 +90,22 @@ export class Furi extends url.URL {
       this.pathname = `${this.pathname}/`;
     }
   }
+
+  toSysPath(windowsLongPath: boolean = false): string {
+    return toSysPath(this, windowsLongPath);
+  }
+
+  toPosixPath(): string {
+    return toPosixPath(this);
+  }
+
+  toWindowsShortPath(): string {
+    return toWindowsShortPath(this);
+  }
+
+  toWindowsLongPath(): string {
+    return toWindowsLongPath(this);
+  }
 }
 
 /**
@@ -286,7 +302,7 @@ export function parent(input: UrlLike): url.URL {
  * @param windowsLongPath Use long paths on Windows. (default: `false`)
  * @return System-dependent path.
  */
-export function toSysPath(furi: string, windowsLongPath: boolean = false): string {
+export function toSysPath(furi: UrlLike, windowsLongPath: boolean = false): string {
   if (isWindows()) {
     return windowsLongPath ? toWindowsLongPath(furi) : toWindowsShortPath(furi);
   } else {
@@ -310,8 +326,8 @@ export function toSysPath(furi: string, windowsLongPath: boolean = false): strin
  * @param furi File URI to convert.
  * @return Windows short path.
  */
-export function toWindowsShortPath(furi: string): string {
-  const urlObj: url.URL = new url.URL(furi);
+export function toWindowsShortPath(furi: UrlLike): string {
+  const urlObj: url.URL = asFuri(furi);
   if (urlObj.host === "") {
     // Local drive path
     const pathname: string = urlObj.pathname.substring(1);
@@ -319,7 +335,7 @@ export function toWindowsShortPath(furi: string): string {
     return toBackwardSlashes(forward);
   } else {
     // Server path
-    const pathname: string = new url.URL(furi).pathname;
+    const pathname: string = urlObj.pathname;
     const forward: string = pathname.split("/").map(decodeURIComponent).join("/");
     const backward: string = toBackwardSlashes(forward);
     return `\\\\${urlObj.host}${backward}`;
@@ -342,8 +358,8 @@ export function toWindowsShortPath(furi: string): string {
  * @param furi File URI to convert.
  * @return Windows long path.
  */
-export function toWindowsLongPath(furi: string): string {
-  const urlObj: url.URL = new url.URL(furi);
+export function toWindowsLongPath(furi: UrlLike): string {
+  const urlObj: Furi = asFuri(furi);
   if (urlObj.host === "") {
     // Local drive path
     const pathname: string = urlObj.pathname.substring(1);
@@ -352,7 +368,7 @@ export function toWindowsLongPath(furi: string): string {
     return `\\\\?\\${backward}`;
   } else {
     // Server path
-    const pathname: string = new url.URL(furi).pathname;
+    const pathname: string = urlObj.pathname;
     const forward: string = pathname.split("/").map(decodeURIComponent).join("/");
     const backward: string = toBackwardSlashes(forward);
     return `\\\\?\\unc\\${urlObj.host}${backward}`;
@@ -373,8 +389,8 @@ export function toWindowsLongPath(furi: string): string {
  * @param furi File URI to convert.
  * @return Posix path.
  */
-export function toPosixPath(furi: string): string {
-  const urlObj: url.URL = new url.URL(furi);
+export function toPosixPath(furi: UrlLike): string {
+  const urlObj: Furi = asFuri(furi);
   if (urlObj.host !== "" && urlObj.host !== "localhost") {
     assert.fail(`Expected \`host\` to be "" or "localhost": ${furi}`);
   }

--- a/src/test/posix.spec.ts
+++ b/src/test/posix.spec.ts
@@ -1,5 +1,5 @@
 import chai from "chai";
-import { fromPosixPath, toPosixPath } from "../lib";
+import { fromPosixPath, Furi, toPosixPath } from "../lib";
 
 interface TestItem {
   name?: string;
@@ -139,6 +139,10 @@ describe("toPosixPath", function () {
       const title: string = item.name !== undefined ? `${item.name}: ${input}` : input;
       it(title, () => {
         const actual: string = toPosixPath(input);
+        chai.assert.strictEqual(actual, expected);
+      });
+      it(`${title} (Furi)`, () => {
+        const actual: string = new Furi(input).toPosixPath();
         chai.assert.strictEqual(actual, expected);
       });
     }

--- a/src/test/windows.spec.ts
+++ b/src/test/windows.spec.ts
@@ -1,5 +1,5 @@
 import chai from "chai";
-import { fromWindowsPath, toWindowsLongPath, toWindowsShortPath } from "../lib";
+import { fromWindowsPath, Furi, toWindowsLongPath, toWindowsShortPath } from "../lib";
 
 interface TestItem {
   name?: string;
@@ -174,6 +174,11 @@ describe("toWindowsShortPath", function () {
       const actual: string = toWindowsShortPath(item.furi);
       chai.assert.strictEqual(actual, expected);
     });
+    it(`${title} (Furi)`, () => {
+      const expected: string = item.shortWindowsPath;
+      const actual: string = new Furi(item.furi).toWindowsShortPath();
+      chai.assert.strictEqual(actual, expected);
+    });
   }
 });
 
@@ -183,6 +188,11 @@ describe("toWindowsLongPath", function () {
     it(title, () => {
       const expected: string = item.longWindowsPath;
       const actual: string = toWindowsLongPath(item.furi);
+      chai.assert.strictEqual(actual, expected);
+    });
+    it(`${title} (Furi)`, () => {
+      const expected: string = item.longWindowsPath;
+      const actual: string = new Furi(item.furi).toWindowsLongPath();
       chai.assert.strictEqual(actual, expected);
     });
   }


### PR DESCRIPTION
This commit adds the `toSysPath`, `toPosixPath`, `toShortWindowsPath` and `toLongWindowsPath` methods to the `Furi` class. They just act as shortcuts for the corresponding functions. This commit also allows these conversion functions to accept a `URL` instance.